### PR TITLE
Allow mcphost to work with this MCP

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,16 @@ const server = new McpServer({
 server.tool(
   "list-all-tools",
   "List all available tools from all connected servers. Before starting any task based on the user’s request, always begin by using this tool to get a list of any additional tools that may be available for use.",
-  {}, // Use empty object when there are no parameters
+  {
+    type: "object",
+    properties: {
+      _dummy: {
+        type: "boolean",
+        description: "Dummy property to make the tool valid. Pass true.",
+      },
+    },
+    required: [],
+  },
   async (args, extra) => {
     try {
       const servers = serverManager.getConnectedServers();


### PR DESCRIPTION
See https://github.com/mark3labs/mcphost/issues/54

Before:

```
Error calling tool! list-all-tools: MCP error -32602: Invalid arguments for tool list-all-tools: [
  {                                                                                               
    "code": "invalid_type",                                                                       
    "expected": "object",                                                                         
    "received": "undefined",                                                                      
    "path": [],                                                                                   
    "message": "Required"                                                                         
  }                                                                                               
]            
```

After:

<img width="851" alt="image" src="https://github.com/user-attachments/assets/6c85ff5f-9f66-4ad4-a28f-e49a0272d2ed" />


Unfortunately, I could not get qwen3 to properly follow my instructions and actually call the call-tool correctly. But this definitely got me closer.