### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@
 
 A hub server that connects to and manages other MCP (Model Context Protocol) servers.
 
+<a href="https://glama.ai/mcp/servers/@warpdev/mcp-hub-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@warpdev/mcp-hub-mcp/badge" alt="Hub Server MCP server" />
+</a>
+
 ## Overview
 
 This project builds an MCP hub server that connects to and manages multiple MCP (Model Context Protocol) servers through a single interface.


### PR DESCRIPTION
This PR adds a badge for the [MCP Hub MCP Server](https://glama.ai/mcp/servers/@warpdev/mcp-hub-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@warpdev/mcp-hub-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@warpdev/mcp-hub-mcp/badge" alt="Hub Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.